### PR TITLE
Bioc 3.11,  R 4.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ r:
 
 matrix:
   allow_failures:
-    - r: bioc-devel
+    - r: bioc-release
 
 bioc_required: true
 bioc_check: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: peakPantheR
 Title: Peak Picking and Annotation of High Resolution Experiments
-Version: 1.1.0
-Date: 2020-01-21
+Version: 1.1.1
+Date: 2020-03-04
 Authors@R: c(person("Arnaud", "Wolfer", email = "adwolfer@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-5856-3218")),
 	person("Goncalo", "Correia", email = "gscorreia89@gmail.com", role = "aut", comment = c(ORCID = "0000-0001-8271-9294")),
 	person("Jake", "Pearce", email = "jake.pearce@gmail.com", role = "ctb"),
 	person("Caroline", "Sands", email = "caz119@hotmail.co.uk", role = "ctb"))
 Description: An automated pipeline for the detection, integration and reporting of predefined features across a large number of mass spectrometry data files.
 Depends: 
-	R (>= 3.6.0)
+	R (>= 4.0)
 Imports: 
 	foreach (>= 1.4.4),
 	doParallel (>= 1.0.11),

--- a/R/extractSignalRawData.R
+++ b/R/extractSignalRawData.R
@@ -180,8 +180,8 @@ extractSignalRawData_checkInput <- function(rt, mz, msLevel, verbose) {
     }
     # both rt and mz have same number of rows (unless one of them has only 1row)
     if (!missing(rt) & !missing(mz)) {
-        if ((class(rt) %in% c("matrix", "data.frame")) &
-            (class(mz) %in% c("matrix", "data.frame"))) {
+        if (any(is(rt, "matrix"), is(rt, "data.frame")) &
+            any(is(mz, "matrix"), is(mz, "data.frame"))) {
             if (nrow(rt) != nrow(mz)) {
                 if ((nrow(rt) != 1) & (nrow(mz) != 1)) {
                     stop('Check input \"rt\" and \"mz\" matrix or ',

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,8 +1,2 @@
-Changes in version 0.99.3 (2019-10-01)
-+ Revisions for Bioconductor submission
-
-Changes in version 0.99.2 (2019-09-10)
-+ Revisions for Bioconductor submission
-
-Changes in version 0.99.0 (2019-06-09)
-+ Submitted to Bioconductor
+Changes in version 1.1.1 (2020-03-04)
++ Compatibility with R 4.0.0


### PR DESCRIPTION
Fix `Conditional Length >1` and `Class == vs is/inherits` [errors in R 4.0](http://bioconductor.org/developers/how-to/troubleshoot-build-report/#classEq) for Bioc 3.11