### PR TITLE
Bioc 3.11, unittest tolerance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: peakPantheR
 Title: Peak Picking and Annotation of High Resolution Experiments
-Version: 1.1.1
-Date: 2020-03-04
+Version: 1.1.2
+Date: 2020-04-05
 Authors@R: c(person("Arnaud", "Wolfer", email = "adwolfer@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-5856-3218")),
 	person("Goncalo", "Correia", email = "gscorreia89@gmail.com", role = "aut", comment = c(ORCID = "0000-0001-8271-9294")),
 	person("Jake", "Pearce", email = "jake.pearce@gmail.com", role = "ctb"),
@@ -28,7 +28,7 @@ BugReports: https://github.com/phenomecentre/peakPantheR/issues/new
 URL: https://github.com/phenomecentre/peakPantheR
 Encoding: UTF-8
 LazyData: false
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Suggests: testthat,
 	faahKO,
 	msdata,

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,2 +1,4 @@
+Changes in version 1.1.2 (2020-04-05)
++ Correct test tolerance for Win on R 4.0.0
 Changes in version 1.1.1 (2020-03-04)
 + Compatibility with R 4.0.0

--- a/tests/testthat/test_peakPantheR_singleFileSearch.R
+++ b/tests/testthat/test_peakPantheR_singleFileSearch.R
@@ -232,7 +232,7 @@ test_that('change peak fitting params with ..., no peakStatistic, no plotEICsPat
   
   # Check results
   expect_equal(result_singleFileSearch$result$TIC, expected_TIC)
-  expect_equal(result_singleFileSearch$result$peakTable, expected_peakTable, tolerance=1e-7)
+  expect_equal(result_singleFileSearch$result$peakTable, expected_peakTable, tolerance=1e-6)
   expect_equal(result_singleFileSearch$result$curveFit, expected_curveFit, tolerance=1e-5)
   expect_equal(result_singleFileSearch$result$ROIsDataPoint, expected_ROIsDataPoint)
   expect_equal(result_singleFileSearch$result$acquTime, expected_acquTime)


### PR DESCRIPTION
Correct unittest tolerance error on windows:
```
test_check("peakPantheR")
  -- 1. Failure: change peak fitting params with ..., no peakStatistic, no plotEIC
  result_singleFileSearch$result$peakTable not equal to `expected_peakTable`.
  Component "maxIntPredicted": Mean relative difference: 1.117975e-07
```