### PR TITLE
annotationDiagnosticMultiplot bugfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: peakPantheR
 Title: Peak Picking and Annotation of High Resolution Experiments
-Version: 1.15.2
-Date: 2023-10-02
+Version: 1.15.3
+Date: 2023-10-03
 Authors@R: c(person("Arnaud", "Wolfer", email = "adwolfer@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-5856-3218")),
 	person("Goncalo", "Correia", email = "gscorreia89@gmail.com", role = "aut", comment = c(ORCID = "0000-0001-8271-9294")),
 	person("Jake", "Pearce", email = "jake.pearce@gmail.com", role = "ctb"),

--- a/R/plotAnnotationDiagnosticMultiplot.R
+++ b/R/plotAnnotationDiagnosticMultiplot.R
@@ -122,13 +122,13 @@ annotDiagMultiplot_linkAxes <- function(tmp_EIC, tmp_rtPeakwidthVert,
         tmp_peakAreaHorz, tmp_areaHisto) {
 
     # link axis (same lim)
-    # EIC + rt peakwidth (is rotated, use y in histogram)
+    # EIC + rt peakwidth (is rotated, but ggplot fixed it no more use y pkwidth)
     minXEIC <- min(ggplot2::layer_scales(tmp_EIC)$x$range$range[1],
-                ggplot2::layer_scales(tmp_rtPeakwidthVert)$y$range$range[1])
+                ggplot2::layer_scales(tmp_rtPeakwidthVert)$x$range$range[1])
     maxXEIC <- max(ggplot2::layer_scales(tmp_EIC)$x$range$range[2],
-                ggplot2::layer_scales(tmp_rtPeakwidthVert)$y$range$range[2])
+                ggplot2::layer_scales(tmp_rtPeakwidthVert)$x$range$range[2])
     tmp_EIC <- tmp_EIC + ggplot2::xlim(minXEIC, maxXEIC)
-    tmp_rtPeakwidthVert <- tmp_rtPeakwidthVert + ggplot2::ylim(minXEIC, maxXEIC)
+    tmp_rtPeakwidthVert <- tmp_rtPeakwidthVert + ggplot2::xlim(minXEIC, maxXEIC)
 
     # rt peakwidth runOrder + histo (is rotated, use x in histo)
     minYRT <- min(ggplot2::layer_scales(tmp_rtPeakwidthHorz)$y$range$range[1],

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -2,3 +2,4 @@ Changes in version 1.15.1 (2023-08-06)
 - corrections in vignettes
 Changes in version 1.15.2 (2023-10-02)
 - ROI, uROI and FIR input checks for NA in rtMin, rtMax, mzMin and mzMax
+Changes in version 1.15.3 (2023-10-03)

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -3,3 +3,4 @@ Changes in version 1.15.1 (2023-08-06)
 Changes in version 1.15.2 (2023-10-02)
 - ROI, uROI and FIR input checks for NA in rtMin, rtMax, mzMin and mzMax
 Changes in version 1.15.3 (2023-10-03)
+- correct `plotAnnotationDiagnosticMultiplot` axes limit  after change in ggplot2 behaviour following a rotation

--- a/inst/shiny-GUI/peakPantheR-App/server.R
+++ b/inst/shiny-GUI/peakPantheR-App/server.R
@@ -1,12 +1,12 @@
 # server.R
 
 # peakPantheR-App
-# Based on peakPantheR v1.3.0, R >= 4.0, shiny >= 1.0.5, bslib
+# Based on peakPantheR v1.15.0, R >= 4.3, shiny >= 1.0.5, bslib
 # National Phenome Centre
-# 18/04/2022
+# 02/10/2023
 # Licensed under GPLv3	
 #
-# Copyright (C) {2022}  {National Phenome Centre}
+# Copyright (C) {2023}  {National Phenome Centre}
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,8 +24,8 @@
 #require(shiny)
 
 
-# increase upload size to 500MB
-options(shiny.maxRequestSize=500*1024^2)
+# increase upload size to 30Gb
+options(shiny.maxRequestSize=30000*1024^2)
 # define max number of parallel cores
 maxCores <- parallel::detectCores()
 # known curve fitting methods

--- a/inst/shiny-GUI/peakPantheR-App/ui.R
+++ b/inst/shiny-GUI/peakPantheR-App/ui.R
@@ -1,12 +1,12 @@
 # ui.R
 
 # peakPantheR-App
-# Based on peakPantheR v1.3.0, R >= 4.0, shiny >= 1.0.5, bslib
+# Based on peakPantheR v1.15.0, R >= 4.3, shiny >= 1.0.5, bslib
 # National Phenome Centre
-# 18/04/2022
+# 02/10/2023
 # Licensed under GPLv3	
 #
-# Copyright (C) {2022}  {National Phenome Centre}
+# Copyright (C) {2023}  {National Phenome Centre}
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Fix to `annotationDiagnosticMultiplot` following ggplot2 change in behaviour regarding rotated axes, which meant we were setting the x and y lims wrong